### PR TITLE
Google Books APIでの取得条件変更

### DIFF
--- a/app/controllers/materials_controller.rb
+++ b/app/controllers/materials_controller.rb
@@ -84,7 +84,8 @@ class MaterialsController < ApplicationController
       url = ENV.fetch('GOOGLE_BOOKS_API_URL')
       text = params[:search]
       api_key = ENV.fetch('GOOGLE_BOOKS_API_KEY')
-      res = Faraday.get(url, q: text, langRestrict: 'ja', maxResults: 30, orderBy: 'relevance', key: api_key)
+      query = "intitle:#{text}"
+      res = Faraday.get(url, q: query, langRestrict: 'ja', maxResults: 30, orderBy: 'newest', key: api_key)
       @google_materials = JSON.parse(res.body)
     end
   end


### PR DESCRIPTION
【Google Books API取得条件変更】
○順序変更
変更前：relevance(検索語句の関連性の順)
変更後：newest(公開されたものから新しい順に結果を返す)

○検索キーワードに特別キーを追加
　intitle：キーワードの後に続くテキストがタイトルに含まれている物
